### PR TITLE
Slsa update

### DIFF
--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -32,7 +32,7 @@ jobs:
       id-token: write # To sign.
       contents: write # To upload release assets.
       actions: read   # To read workflow path.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.2.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.4.0
     with:
       go-version: 1.19
       # =============================================================================================================

--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -39,16 +39,26 @@ jobs:
       #     Optional: For more options, see https://github.com/slsa-framework/slsa-github-generator#golang-projects
       # =============================================================================================================
 
-  non_slsa:
+  goreleaser:
+    runs-on: ubuntu-latest
     permissions:
-      id-token: write # To sign.
-      contents: write # To upload release assets.
-      actions: read   # To read workflow path.
-    uses: goreleaser/goreleaser-action@v4
-    with:
-      # either 'goreleaser' (default) or 'goreleaser-pro':
-      distribution: goreleaser
-      version: latest
-      args: release --rm-dist
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.19.4'
+          cache: true
+      # More assembly might be required: Docker logins, GPG, etc. It all depends
+      # on your needs.
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro':
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -39,3 +39,16 @@ jobs:
       #     Optional: For more options, see https://github.com/slsa-framework/slsa-github-generator#golang-projects
       # =============================================================================================================
 
+  non_slsa:
+    permissions:
+      id-token: write # To sign.
+      contents: write # To upload release assets.
+      actions: read   # To read workflow path.
+    uses: goreleaser/goreleaser-action@v4
+    with:
+      # either 'goreleaser' (default) or 'goreleaser-pro':
+      distribution: goreleaser
+      version: latest
+      args: release --rm-dist
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,19 +29,17 @@ builds:
       - CGO_ENABLED=0
 
 archives:
-  - format: tar.gz
-    # this name template makes the OS and Arch compatible with the results of uname.
-    name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
+  - 
+    replacements:
+      linux: Linux
+      amd64: x86_64
+      arm:   arm32v{{ .Arm }}
+    format: tar.gz
     # use zip for windows archives
     format_overrides:
     - goos: windows
       format: zip
+
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,7 +31,7 @@ archives:
       {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
+      {{- else if .Arm }}arm32v{{ .Arm }}
       {{- else }}{{ .Arch }}{{ end }}
     format: tar.gz
     # use zip for windows archives

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,7 +31,8 @@ archives:
       {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
-      {{- else if .Arm }}arm32v{{ .Arm }}
+      {{- else if eq .Arch "arm64" }}aarch64
+      {{- else if .Arm }}armv{{ .Arm }}l
       {{- else }}{{ .Arch }}{{ end }}
     format: tar.gz
     # use zip for windows archives

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,11 +27,12 @@ builds:
       - CGO_ENABLED=0
 
 archives:
-  - 
-    replacements:
-      linux: Linux
-      amd64: x86_64
-      arm:   arm32
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     format: tar.gz
     # use zip for windows archives
     format_overrides:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,7 @@ before:
   hooks:
     # You may remove this if you don't use go modules.
     - go mod tidy
-    # you may remove this if you don't need go generate
-    - go generate ./...
+
 builds:
   - id: setup-network-environment
     # handled by slsa-goreleaser

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,7 +33,7 @@ archives:
     replacements:
       linux: Linux
       amd64: x86_64
-      arm:   arm32v{{ .Arm }}
+      arm:   arm32
     format: tar.gz
     # use zip for windows archives
     format_overrides:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,8 +14,6 @@ builds:
 
     goos:
       - linux
-      - linux
-      - linux
 
     goarch:
       - amd64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,8 +31,7 @@ archives:
       {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "arm64" }}aarch64
-      {{- else if .Arm }}armv{{ .Arm }}l
+      {{- else if .Arm }}arm32v{{ .Arm }}
       {{- else }}{{ .Arch }}{{ end }}
     format: tar.gz
     # use zip for windows archives

--- a/.slsa-goreleaser.yml
+++ b/.slsa-goreleaser.yml
@@ -26,15 +26,4 @@ goarch: amd64
 # Binary output name.
 # {{ .Os }} will be replaced by goos field in the config file.
 # {{ .Arch }} will be replaced by goarch field in the config file.
-binary: setup-network-environment
-
-archives:
-  - name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "arm64" }}aarch64
-      {{- else if .Arm }}armv{{ .Arm }}l
-      {{- else }}{{ .Arch }}{{ end }}
-    format: tar.gz
-    # use zip for windows archives
+binary: setup-network-environment-{{ .Os }}-{{ .Arch }}

--- a/.slsa-goreleaser.yml
+++ b/.slsa-goreleaser.yml
@@ -26,4 +26,4 @@ goarch: amd64
 # Binary output name.
 # {{ .Os }} will be replaced by goos field in the config file.
 # {{ .Arch }} will be replaced by goarch field in the config file.
-binary: binary-{{ .Os }}-{{ .Arch }}
+binary: setup-network-environment-{{ .Os }}-{{ .Arch }}

--- a/.slsa-goreleaser.yml
+++ b/.slsa-goreleaser.yml
@@ -26,4 +26,15 @@ goarch: amd64
 # Binary output name.
 # {{ .Os }} will be replaced by goos field in the config file.
 # {{ .Arch }} will be replaced by goarch field in the config file.
-binary: setup-network-environment-{{ .Os }}-{{ .Arch }}
+binary: setup-network-environment
+
+archives:
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "arm64" }}aarch64
+      {{- else if .Arm }}armv{{ .Arm }}l
+      {{- else }}{{ .Arch }}{{ end }}
+    format: tar.gz
+    # use zip for windows archives


### PR DESCRIPTION
Add goreleaser for additional binaries. It was unclear to me how I could create an archive from the SLSA generator, so it puts uploads the binary directly to the release artifacts. Goreleaser puts them in compressed folders.